### PR TITLE
fix: server crash: perform arithmetic on local cache_value (a boolean value)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -80,7 +80,7 @@ core.register_on_mods_loaded(function()
 				if basename:find("%.[0-9]$") then
 					basename = basename:gsub("%.[0-9]$", "")
 					cache_value = sounds.cache[basename]
-					if not cache_value then
+					if type(cache_value) ~= "number" then
 						cache_value = 1
 					else
 						cache_value = cache_value + 1


### PR DESCRIPTION
```
2022-09-09 16:41:53: ERROR[Main]: ModError: Runtime error from mod 'sounds' in callback on_mods_loaded(): ...mods/sounds/init.lua:86: attempt to perform arithmetic on local 'cache_value' (a boolean value)
2022-09-09 16:41:53: ERROR[Main]: stack traceback:
2022-09-09 16:41:53: ERROR[Main]: 	...mods/sounds/init.lua:86: in function <...mods/sounds/init.lua:69>
2022-09-09 16:41:53: ERROR[Main]: 	...builtin/game/register.lua:431: in function <.../builtin/game/register.lua:417>

```